### PR TITLE
Force API call payload result in same for batch of beacons

### DIFF
--- a/config/airseeker.example.json
+++ b/config/airseeker.example.json
@@ -28,10 +28,6 @@
     "0x1d65c1f1e127a41cebd2339f823d0290322c63f3044380cbac105db8e522ebb9": {
       "endpointId": "0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc",
       "parameters": "0x31730000000000000000000000000000000000000000000000000000000000006e616d65000000000000000000000000000000000000000000000000000000005841552f55534400000000000000000000000000000000000000000000000000"
-    },
-    "0xc3267366934b1f9b1284516a78c206f4374ab53b17d2f5cf151f49c7666c4dfa": {
-      "endpointId": "0x3528e42b017a5fbf9d2993a2df04efc3ed474357575065a111b054ddf9de2acc",
-      "parameters": "0x317300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
     }
   },
   "endpoints": {
@@ -41,7 +37,6 @@
     }
   },
   "triggers": {
-    "dataFeedUpdates": {},
     "signedApiUpdates": [
       {
         "signedApiName": "Nodary",
@@ -50,9 +45,8 @@
           "0xe1d3bc514126e305f90484f977be17996f9389613607ac88aee3c955919fda59",
           "0xc139000a53aa2863d802a263a840559398d2120f50f464474188a567a59ad452"
         ],
-        "operationTemplateId": "0xc3267366934b1f9b1284516a78c206f4374ab53b17d2f5cf151f49c7666c4dfa",
-        "fetchInterval": 30,
-        "updateDelay": 60
+        "fetchInterval": 5,
+        "updateDelay": 30
       }
     ]
   },
@@ -90,7 +84,13 @@
             { "name": "_type", "fixed": "int256" },
             { "name": "_times", "fixed": "1000000000000000000" }
           ],
-          "preProcessingSpecifications": [],
+          "preProcessingSpecifications": [
+            {
+              "environment": "Node",
+              "value": "const output = {};",
+              "timeoutMs": 5000
+            }
+          ],
           "postProcessingSpecifications": [
             {
               "environment": "Node",

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,9 +6,9 @@ import { configSchema } from './validation';
 
 type Secrets = Record<string, string | undefined>;
 
-export const loadConfig = (configPath: string, secrets: Record<string, string | undefined>) => {
+export const loadConfig = async (configPath: string, secrets: Record<string, string | undefined>) => {
   const rawConfig = readConfig(configPath);
-  const parsedConfigRes = parseConfigWithSecrets(rawConfig, secrets);
+  const parsedConfigRes = await parseConfigWithSecrets(rawConfig, secrets);
   if (!parsedConfigRes.success) {
     throw new Error(`Invalid Airseeker configuration file: ${parsedConfigRes.error}`);
   }
@@ -29,7 +29,7 @@ export const parseConfigWithSecrets = (config: unknown, secrets: unknown) => {
   const parseSecretsRes = parseSecrets(secrets);
   if (!parseSecretsRes.success) return parseSecretsRes;
 
-  return parseConfig(interpolateSecrets(config, parseSecretsRes.data));
+  return parseConfigAsync(interpolateSecrets(config, parseSecretsRes.data));
 };
 
 export const parseSecrets = (secrets: unknown) => {
@@ -39,9 +39,8 @@ export const parseSecrets = (secrets: unknown) => {
   return result;
 };
 
-export const parseConfig = (config: unknown) => {
-  const parseConfigRes = configSchema.safeParse(config);
-  return parseConfigRes;
+export const parseConfigAsync = (config: unknown) => {
+  return configSchema.safeParseAsync(config);
 };
 
 // Regular expression that does not match anything, ensuring no escaping or interpolation happens

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ export const handleStopSignal = (signal: string) => {
 };
 
 export async function main() {
-  const config = loadConfig(path.join(__dirname, '..', 'config', 'airseeker.json'), process.env);
+  const config = await loadConfig(path.join(__dirname, '..', 'config', 'airseeker.json'), process.env);
   initializeState(config);
 
   // TODO Remove

--- a/src/make-request.ts
+++ b/src/make-request.ts
@@ -156,8 +156,11 @@ export const makeTemplateRequests = async (signedApiUpdate: SignedApiUpdate): Pr
     config: { beacons, endpoints, templates, ois, apiCredentials },
     apiLimiters,
   } = getState();
-  const { beaconIds, operationTemplateId } = signedApiUpdate;
+  const { beaconIds } = signedApiUpdate;
 
+  // Because each beacon have same operation, just take first one as operational template
+  // See the function validateTriggerReferences in validation.ts
+  const operationTemplateId = beacons[beaconIds[0]].templateId;
   const operationTemplate = templates[operationTemplateId];
 
   const parameters = abi.decode(operationTemplate.parameters);


### PR DESCRIPTION
Nodary has an API endpoint that returns all feed values at once like following:
```json
{
"AAPL/USD":{"value":174.21,"timestamp":1694638194406,"category":"stock"},
"AAVE/USD":{"value":53.88,"timestamp":1694641785444,"category":"crypto"},
"ADA/USD":{"value":0.24876575,"timestamp":1694641785444,"category":"crypto"},
"ALGO/USD":{"value":0.09096,"timestamp":1694641785444,"category":"crypto"},
...
"ZRX/USD":{"value":0.174447,"timestamp":1694641785444,"category":"crypto"}
}
```
Firstly, to utilize this endpoint and fetching all beacon data at once, I came up with a solution that there is an operation template for each `signedApiUpdates` trigger as [here](https://github.com/nodaryio/signed-data-pusher/blob/d1971db4f03e8d2bf7fe97b1de0ff33de4aee68b/config/airseeker.example.json#L53). So only one API call was made according to that template then returned payload was being parsed by post-process for each beacon's template parameter. As you can guess, it's far than elegant solution. 

In this PR, I am pushing the user so hard that for each beacon included in 'beaconIds', it will return the same API call payload operationally as the endpoint indicated by each beacon. The easiest way to achieve this is by using pre-processing an example [here](https://github.com/nodaryio/signed-data-pusher/blob/d7375554733a334f8b2dde7315ca7b5ef057a174/config/airseeker.example.json#L90). Remaining is same before, just parsing API call response according to template parameters in post-processing.